### PR TITLE
プロダクションDBのリセット用rake

### DIFF
--- a/lib/tasks/db/connection.rake
+++ b/lib/tasks/db/connection.rake
@@ -1,0 +1,13 @@
+namespace :db do
+    namespace :connection do
+      desc "Close all DB connections"
+      task close: :environment do
+        db_name = ActiveRecord::Base.connection.current_database
+        ActiveRecord::Base.connection.execute(ActiveRecord::Base.sanitize_sql_array([ <<~SQL, db_name ]))
+          SELECT pg_terminate_backend(pid)
+          FROM pg_stat_activity
+          WHERE datname = '%s' AND pid <> pg_backend_pid();
+        SQL
+      end
+    end
+  end


### PR DESCRIPTION
セッションか切断できず、リセットに失敗する。
対処法として``app/lib/db/connection.rake``を作成し、``rails db:connection:close``を実行することで改善を図りました。